### PR TITLE
Regress to previous version of predictor

### DIFF
--- a/TurnipTracker/Model/PredictedPriceSeries.cs
+++ b/TurnipTracker/Model/PredictedPriceSeries.cs
@@ -17,7 +17,7 @@ namespace TurnipTracker.Model
 
         public double CategoryTotalProbability { get; set; }
 
-        public PredictedPriceSeries(string patternDesc, PredictionPattern patternNumber, List<(int min, int max)> prices, double probability)
+        public PredictedPriceSeries(string patternDesc, PredictionPattern patternNumber, List<(int min, int max)> prices, double probability = 0)
         {
             PatternDesc = patternDesc;
             PatternNumber = patternNumber;

--- a/TurnipTracker/Model/Predictor.cs
+++ b/TurnipTracker/Model/Predictor.cs
@@ -212,23 +212,22 @@ namespace TurnipTracker.Model
 {
     // Originally developed by Mike Bryant, with great thanks to Ninji
     // Original project location: https://github.com/mikebryant/ac-nh-turnip-prices
-    // This is a C# version of https://github.com/mikebryant/ac-nh-turnip-prices/blob/master/js/predictions.js as April 27th
+    // This is a C# version of https://github.com/mikebryant/ac-nh-turnip-prices/blob/master/js/predictions.js
 
-    [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Converted from JS")]
     [SuppressMessage("Style", "IDE0007:Use implicit type", Justification = "Explicit types are useful when converting from dynamically typed JS")]
-    public sealed class Predictor
+    public static class Predictor
     {
         // The reverse-engineered code is not perfectly accurate, especially as it's not
         // 32-bit ARM floating point. So, be tolerant of slightly unexpected inputs
-        public double FudgeFactor { get; private set; }
+        const double fudgeFactor = 5;
 
-#pragma warning disable CA1819 // Properties should not return arrays
-        public int[] Prices { get; }
-#pragma warning restore CA1819 // Properties should not return arrays
-
-        public bool FirstBuy { get; }
-
-        public PredictionPattern PreviousPattern { get; }
+        static readonly Dictionary<PredictionPattern, int> patternCounts = new Dictionary<PredictionPattern, int>
+        {
+            { PredictionPattern.Fluctuating, 56 },
+            { PredictionPattern.LargeSpike, 7 },
+            { PredictionPattern.Decreasing, 1 },
+            { PredictionPattern.SmallSpike, 8 },
+        };
 
         static readonly Dictionary<PredictionPattern, Dictionary<PredictionPattern, double>> probabilityMatrix =
             new Dictionary<PredictionPattern, Dictionary<PredictionPattern, double>>
@@ -269,310 +268,13 @@ namespace TurnipTracker.Model
 
         const double rateMultiplier = 10000;
 
-        static double range_length((double, double) range) => range.Item2 - range.Item1;
-
-        static int Clamp(int x, int min, int max) => (int)Math.Min(Math.Max(x, min), max);
-
-        static (double, double) range_intersect((double, double) range1, (double, double) range2)
-        {
-            if (range1.Item1 > range2.Item2 || range1.Item2 < range2.Item1)
-                return default;
-
-            return (Math.Max(range1.Item1, range2.Item1), Math.Min(range1.Item2, range2.Item2));
-        }
-
-        static double range_intersect_length((double, double) range1, (double, double) range2)
-        {
-            if (range1.Item1 > range2.Item2 || range1.Item2 < range2.Item1)
-                return 0;
-
-            return range_length(range_intersect(range1, range2));
-        }
-
-
-        /**
-        * Accurately sums a list of floating point numbers.
-        * See https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements
-        * for more information.
-        * @param {number[]} input
-        * @returns {number} The sum of the input.
-        */
-        static double float_sum(double[] input)
-        {
-            // Uses the improved Kahan–Babuska algorithm introduced by Neumaier.
-            double sum = 0;
-            // The "lost bits" of sum.
-            double c = 0;
-            for (int i = 0; i < input.Length; i++)
-            {
-                double cur = input[i];
-                double t = sum + cur;
-                if (Math.Abs(sum) >= Math.Abs(cur))
-                {
-                    c += (sum - t) + cur;
-                }
-                else
-                {
-                    c += (cur - t) + sum;
-                }
-                sum = t;
-            }
-            return sum + c;
-        }
-
-        /**
-         * Accurately returns the prefix sum of a list of floating point numbers.
-         * See https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements
-         * for more information.
-         * @param {number[]} input
-         * @returns {[number, number][]} The prefix sum of the input, such that
-         * output[i] = [sum of first i integers, error of the sum].
-         * The "true" prefix sum is equal to the sum of the pair of numbers, but it is
-         * explicitly returned as a pair of numbers to ensure that the error portion
-         * isn't lost when subtracting prefix sums.
-         */
-        static List<(double sum, double error)> prefix_float_sum(double[] input)
-        {
-            var prefix_sum = new List<(double, double)>();
-            double sum = 0;
-            double c = 0;
-            for (int i = 0; i < input.Length; i++)
-            {
-                double cur = input[i];
-                double t = sum + cur;
-                if (Math.Abs(sum) >= Math.Abs(cur))
-                {
-                    c += (sum - t) + cur;
-                }
-                else
-                {
-                    c += (cur - t) + sum;
-                }
-                sum = t;
-                prefix_sum.Add((sum, c));
-            }
-            return prefix_sum;
-        }
-
-        /*
-         * Probability Density Function of rates.
-         * Since the PDF is continuous*, we approximate it by a discrete probability function:
-         *   the value in range [x, x + 1) has a uniform probability
-         *   prob[x - value_start];
-         *
-         * Note that we operate all rate on the (* RATE_MULTIPLIER) scale.
-         *
-         * (*): Well not really since it only takes values that "float" can represent in some form, but the
-         * space is too large to compute directly in JS.
-         */
-        class PDF
-        {
-            int value_start;
-            int value_end;
-            double[] prob;
-
-            /**
-            * Initialize a PDF in range [a, b], a and b can be non-integer.
-            * if uniform is true, then initialize the probability to be uniform, else initialize to a
-            * all-zero (invalid) PDF.
-            * @param {number} a - Left end-point.
-            * @param {number} b - Right end-point end-point.
-            * @param {boolean} uniform - If true, initialise with the uniform distribution.
-            */
-            public PDF(double a, double b, bool uniform = true)
-            {
-                // We need to ensure that [a, b] is fully contained in [value_start, value_end].
-                /** @type {number} */
-                value_start = (int)Math.Floor(a);
-                /** @type {number} */
-                value_end = (int)Math.Ceiling(b);
-                (double, double) range = (a, b);
-                double total_length = range_length(range);
-                /** @type {number[]} */
-                prob = new double[value_end - value_start];
-                if (uniform)
-                {
-                    for (int i = 0; i < prob.Length; i++)
-                    {
-                        prob[i] = range_intersect_length(range_of(i), range) / total_length;
-                    }
-                }
-            }
-
-            /**
-               * Calculates the interval represented by this.prob[idx]
-               * @param {number} idx - The index of this.prob
-               * @returns {[number, number]} The interval representing this.prob[idx].
-               */
-            (double, double) range_of(int idx)
-            {
-                // We intentionally include the right end-point of the range.
-                // The probability of getting exactly an endpoint is zero, so we can assume
-                // the "probability ranges" are "touching".
-                return (value_start + idx, value_start + idx + 1);
-            }
-
-            public double min_value() => value_start;
-
-            public double max_value() => value_end;
-
-            /**
-            * @returns {number} The sum of probabilities before normalisation.
-            */
-            double normalize()
-            {
-                double total_probability = float_sum(prob);
-                for (int i = 0; i < prob.Length; i++)
-                {
-                    prob[i] /= total_probability;
-                }
-                return total_probability;
-            }
-
-            // * Limit the values to be in the range, and return the probability that the value was in this
-            // * range.
-            public double range_limit((double, double) range)
-            {
-                var (start, end) = range;
-                start = Math.Max(start, min_value());
-                end = Math.Min(end, max_value());
-                if (start >= end)
-                {
-                    // Set this to invalid values
-                    value_start = value_end = 0;
-                    prob = Array.Empty<double>();
-                    return 0;
-                }
-
-                start = Math.Floor(start);
-                end = Math.Ceiling(end);
-
-
-                int start_idx = (int)start - value_start;
-                int end_idx = (int)end - value_start;
-                for (int i = start_idx; i < end_idx; i++)
-                {
-                    prob[i] *= range_intersect_length(range_of(i), range);
-                }
-
-                prob = prob.Slice(start_idx, end_idx);
-                value_start = (int)start;
-                value_end = (int)end;
-
-                // The probability that the value was in this range is equal to the total
-                // sum of "un-normalised" values in the range.
-                return normalize();
-            }
-
-            /**
-               * Subtract the PDF by a uniform distribution in [rate_decay_min, rate_decay_max]
-               *
-               * For simplicity, we assume that rate_decay_min and rate_decay_max are both integers.
-               * @param {number} rate_decay_min
-               * @param {number} rate_decay_max
-               * @returns {void}
-               */
-            public void decay(double rate_decay_min, double rate_decay_max)
-            {
-                // In case the arguments aren't integers, round them to the nearest integer.
-                rate_decay_min = Math.Round(rate_decay_min);
-                rate_decay_max = Math.Round(rate_decay_max);
-                // The sum of this distribution with a uniform distribution.
-                // Let's assume that both distributions start at 0 and X = this dist,
-                // Y = uniform dist, and Z = X + Y.
-                // Let's also assume that X is a "piecewise uniform" distribution, so
-                // x(i) = this.prob[Math.floor(i)] - which matches our implementation.
-                // We also know that y(i) = 1 / max(Y) - as we assume that min(Y) = 0.
-                // In the end, we're interested in:
-                // Pr(i <= Z < i+1) where i is an integer
-                // = int. x(val) * Pr(i-val <= Y < i-val+1) dval from 0 to max(X)
-                // = int. x(floor(val)) * Pr(i-val <= Y < i-val+1) dval from 0 to max(X)
-                // = sum val from 0 to max(X)-1
-                //     x(val) * f_i(val) / max(Y)
-                // where f_i(val) =
-                // 0.5 if i-val = 0 or max(Y), so val = i-max(Y) or i
-                // 1.0 if 0 < i-val < max(Y), so i-max(Y) < val < i
-                // as x(val) is "constant" for each integer step, so we can consider the
-                // integral in integer steps.
-                // = sum val from max(0, i-max(Y)) to min(max(X)-1, i)
-                //     x(val) * f_i(val) / max(Y)
-                // for example, max(X)=1, max(Y)=10, i=5
-                // = sum val from max(0, 5-10)=0 to min(1-1, 5)=0
-                //     x(val) * f_i(val) / max(Y)
-                // = x(0) * 1 / 10
-
-                // Get a prefix sum / CDF of this so we can calculate sums in O(1).
-                List<(double sum, double error)> prefix = prefix_float_sum(prob);
-                int max_X = prob.Length;
-                int max_Y = (int)rate_decay_max - (int)rate_decay_min;
-                var newProb = new double[prob.Length + max_Y];
-                for (int i = 0; i < newProb.Length; i++)
-                {
-                    // Note that left and right here are INCLUSIVE.
-                    int left = Math.Max(0, i - max_Y);
-                    int right = Math.Min(max_X - 1, i);
-                    // We want to sum, in total, prefix[right+1], -prefix[left], and subtract
-                    // the 0.5s if necessary.
-                    // This may involve numbers of differing magnitudes, so use the float sum
-                    // algorithm to sum these up.
-                    List<double> numbers_to_sum = new List<double> {
-                        // NOTE: Seems to be an off-by-one error
-                      prefix[right/* + 1*/].sum, prefix[right/* + 1*/].error,
-                      -prefix[left].sum, -prefix[left].error,
-                    };
-                    if (left == i - max_Y)
-                    {
-                        // Need to halve the left endpoint.
-                        numbers_to_sum.Add(-prob[left] / 2);
-                    }
-                    if (right == i)
-                    {
-                        // Need to halve the right endpoint.
-                        // It's guaranteed that we won't accidentally "halve" twice,
-                        // as that would require i-max_Y = i, so max_Y = 0 - which is
-                        // impossible.
-                        numbers_to_sum.Add(-prob[right] / 2);
-                    }
-                    newProb[i] = float_sum(numbers_to_sum.ToArray()) / max_Y;
-                }
-
-                prob = newProb;
-                value_start -= (int)rate_decay_max;
-                value_end -= (int)rate_decay_min;
-                // No need to normalise, as it is guaranteed that the sum of this.prob is 1.
-            }
-        }
-
-        public Predictor(int[] prices, bool firstBuy, PredictionPattern previousPattern)
-        {
-            // The reverse-engineered code is not perfectly accurate, especially as it's not
-            // 32-bit ARM floating point. So, be tolerant of slightly unexpected inputs
-            FudgeFactor = 0;
-            Prices = prices;
-            FirstBuy = firstBuy;
-            PreviousPattern = previousPattern;
-        }
-
         static int IntCeil(double val) => (int)Math.Truncate(val + 0.99999);
 
         static double MinimumRateFromGivenAndBase(int givenPrice, int buyPrice) => rateMultiplier * (givenPrice - 0.99999) / buyPrice;
 
         static double MaximumRateFromGivenAndBase(int givenPrice, int buyPrice) => rateMultiplier * (givenPrice + 0.00001) / buyPrice;
 
-        static (double, double) rate_range_from_given_and_base(int given_price, int buy_price) =>
-              (MinimumRateFromGivenAndBase(given_price, buy_price),
-              MaximumRateFromGivenAndBase(given_price, buy_price));
-
         static int GetPrice(double rate, int basePrice) => IntCeil(rate * basePrice / rateMultiplier);
-
-        static PredictedPriceSeries multiply_generator_probability(PredictedPriceSeries priceSeries, double probability)
-        {
-            return new PredictedPriceSeries(
-                priceSeries.PatternDesc,
-                priceSeries.PatternNumber,
-                priceSeries.Prices,
-                priceSeries.Probability * probability);
-        }
 
         // This corresponds to the code:
         //   for (int i = start; i<start + length; i++)
@@ -583,15 +285,13 @@ namespace TurnipTracker.Model
         //
         // Would modify the predictedPrices array.
         // If the givenPrices won't match, returns false, otherwise returns true
-        double GenerateIndividualRandomPrice(
+        static bool GenerateIndividualRandomPrice(
           int[] givenPrices, List<(int min, int max)> predictedPrices, int start, int length, double rateMin, double rateMax)
         {
             rateMin *= rateMultiplier;
             rateMax *= rateMultiplier;
 
             int buyPrice = givenPrices[0];
-            (double, double) rate_range = (rateMin, rateMax);
-            double prob = 1;
 
             for (int i = start; i < start + length; i++)
             {
@@ -600,22 +300,18 @@ namespace TurnipTracker.Model
 
                 if (i < givenPrices.Length && givenPrices[i] > 0)
                 {
-                    if (givenPrices[i] < minPred - FudgeFactor || givenPrices[i] > maxPred + FudgeFactor)
+                    if (givenPrices[i] < minPred - fudgeFactor || givenPrices[i] > maxPred + fudgeFactor)
                     {
                         // Given price is out of predicted range, so this is the wrong pattern
-                        return 0;
+                        return false;
                     }
-                    // TODO: How to deal with probability when there's fudge factor?
-                    // Clamp the value to be in range now so the probability won't be totally biased to fudged values.
-                    var real_rate_range = rate_range_from_given_and_base(Clamp(givenPrices[i], minPred, maxPred), buyPrice);
-                    prob *= range_intersect_length(rate_range, real_rate_range) / range_length(rate_range);
                     minPred = givenPrices[i];
                     maxPred = givenPrices[i];
                 }
 
                 predictedPrices.Add((minPred, maxPred));
             }
-            return prob;
+            return true;
         }
 
         // This corresponds to the code:
@@ -628,39 +324,35 @@ namespace TurnipTracker.Model
         //
         // Would modify the predictedPrices array.
         // If the givenPrices won't match, returns false, otherwise returns true
-        double GenerateDecreasingRandomPrice(
-         int[] givenPrices, List<(int min, int max)> predictedPrices, int start, int length, double startRateMin,
-         double startRateMax, double rateDecayMin, double rateDecayMax)
+        static bool GenerateDecreasingRandomPrice(
+          int[] givenPrices, List<(int min, int max)> predictedPrices, int start, int length, double rateMin,
+          double rateMax, double rateDecayMin, double rateDecayMax)
         {
-            startRateMin *= rateMultiplier;
-            startRateMax *= rateMultiplier;
+            rateMin *= rateMultiplier;
+            rateMax *= rateMultiplier;
             rateDecayMin *= rateMultiplier;
             rateDecayMax *= rateMultiplier;
 
             int buyPrice = givenPrices[0];
-            var rate_pdf = new PDF(startRateMin, startRateMax);
-            double prob = 1;
 
             for (int i = start; i < start + length; i++)
             {
-                int minPred = GetPrice(rate_pdf.min_value(), buyPrice);
-                int maxPred = GetPrice(rate_pdf.max_value(), buyPrice);
-
+                int minPred = GetPrice(rateMin, buyPrice);
+                int maxPred = GetPrice(rateMax, buyPrice);
                 if (i < givenPrices.Length && givenPrices[i] > 0)
                 {
-                    if (givenPrices[i] < minPred - FudgeFactor || givenPrices[i] > maxPred + FudgeFactor)
+                    if (givenPrices[i] < minPred - fudgeFactor || givenPrices[i] > maxPred + fudgeFactor)
                     {
                         // Given price is out of predicted range, so this is the wrong pattern
-                        return 0;
+                        return false;
                     }
-                    // TODO: How to deal with probability when there's fudge factor?
-                    // Clamp the value to be in range now so the probability won't be totally biased to fudged values.
-                    (double, double) real_rate_range =
-                        rate_range_from_given_and_base(Clamp(givenPrices[i], minPred, maxPred), buyPrice);
-                    prob *= rate_pdf.range_limit(real_rate_range);
-                    if (prob == 0)
+                    if (givenPrices[i] >= minPred || givenPrices[i] <= maxPred)
                     {
-                        return 0;
+                        // The value in the FUDGE_FACTOR range is ignored so the rate range would not be empty.
+                        double realRateMin = MinimumRateFromGivenAndBase(givenPrices[i], buyPrice);
+                        double realRateMax = MaximumRateFromGivenAndBase(givenPrices[i], buyPrice);
+                        rateMin = Math.Max(rateMin, realRateMin);
+                        rateMax = Math.Min(rateMax, realRateMax);
                     }
                     minPred = givenPrices[i];
                     maxPred = givenPrices[i];
@@ -668,9 +360,10 @@ namespace TurnipTracker.Model
 
                 predictedPrices.Add((minPred, maxPred));
 
-                rate_pdf.decay(rateDecayMin, rateDecayMax);
+                rateMin -= rateDecayMax;
+                rateMax -= rateDecayMin;
             }
-            return prob;
+            return true;
         }
 
         // This corresponds to the code:
@@ -681,102 +374,24 @@ namespace TurnipTracker.Model
         //
         // Would modify the predictedPrices array.
         // If the givenPrices won't match, returns false, otherwise returns true
-        double GeneratePeakPrice(
+        static bool GeneratePeakPrice(
             int[] givenPrices, List<(int min, int max)> predictedPrices, int start, double rateMin, double rateMax)
         {
             rateMin *= rateMultiplier;
             rateMax *= rateMultiplier;
 
             int buyPrice = givenPrices[0];
-            double prob = 1;
-            (double, double) rate_range = (rateMin, rateMax);
-
-            // * Calculate the probability first.
-            // Prob(middle_price)
-            if (start + 1 < givenPrices.Length && givenPrices[start + 1] > 0)
-            {
-                int middle_price = givenPrices[start + 1];
-                int min_pred = GetPrice(rateMin, buyPrice);
-                int max_pred = GetPrice(rateMax, buyPrice);
-                if (middle_price < min_pred - FudgeFactor || middle_price > max_pred + FudgeFactor)
-                {
-                    // Given price is out of predicted range, so this is the wrong pattern
-                    return 0;
-                }
-                // TODO: How to deal with probability when there's fudge factor?
-                // Clamp the value to be in range now so the probability won't be totally biased to fudged values.
-                (double, double) real_rate_range =
-                    rate_range_from_given_and_base(Clamp(middle_price, min_pred, max_pred), buyPrice);
-                prob *= range_intersect_length(rate_range, real_rate_range) /
-                  range_length(rate_range);
-                if (prob == 0)
-                {
-                    return 0;
-                }
-
-                rate_range = range_intersect(rate_range, real_rate_range);
-            }
-
-            // Prob(left_price | middle_price), Prob(right_price | middle_price)
-            //
-            // A = rate_range[0], B = rate_range[1], C = rate_min, X = rate, Y = randfloat(rate_min, rate)
-            // rate = randfloat(A, B); sellPrices[work++] = intceil(randfloat(C, rate) * basePrice) - 1;
-            //
-            // => X->U(A,B), Y->U(C,X), Y-C->U(0,X-C), Y-C->U(0,1)*(X-C), Y-C->U(0,1)*U(A-C,B-C),
-            // let Z=Y-C,  Z1=A-C, Z2=B-C, Z->U(0,1)*U(Z1,Z2)
-            // Prob(Z<=t) = integral_{x=0}^{1} [min(t/x,Z2)-min(t/x,Z1)]/ (Z2-Z1)
-            // let F(t, ZZ) = integral_{x=0}^{1} min(t/x, ZZ)
-            //    1. if ZZ < t, then min(t/x, ZZ) = ZZ -> F(t, ZZ) = ZZ
-            //    2. if ZZ >= t, then F(t, ZZ) = integral_{x=0}^{t/ZZ} ZZ + integral_{x=t/ZZ}^{1} t/x
-            //                                 = t - t log(t/ZZ)
-            // Prob(Z<=t) = (F(t, Z2) - F(t, Z1)) / (Z2 - Z1)
-            // Prob(Y<=t) = Prob(Z>=t-C)
-            List<double> iterPrices = new List<double>();
-            if (start < givenPrices.Length) iterPrices.Add(givenPrices[start]);
-            if (start + 2 < givenPrices.Length) iterPrices.Add(givenPrices[start + 2]);
-            foreach (int price in iterPrices)
-            {
-                int min_pred = GetPrice(rateMin, buyPrice) - 1;
-                int max_pred = GetPrice(rate_range.Item2, buyPrice) - 1;
-                if (price < min_pred - FudgeFactor || price > max_pred + FudgeFactor)
-                {
-                    // Given price is out of predicted range, so this is the wrong pattern
-                    return 0;
-                }
-                // TODO: How to deal with probability when there's fudge factor?
-                // Clamp the value to be in range now so the probability won't be totally biased to fudged values.
-                (double, double) rate2_range = rate_range_from_given_and_base(Clamp(price, min_pred, max_pred) + 1, buyPrice);
-                Func<double, double, double> F = (t, ZZ) =>
-                  {
-                      if (t <= 0)
-                      {
-                          return 0;
-                      }
-                      return ZZ < t ? ZZ : t - t * (Math.Log(t) - Math.Log(ZZ));
-                  };
-                double A = rate_range.Item1;
-                double B = rate_range.Item2;
-                double C = rateMin;
-                double Z1 = A - C;
-                double Z2 = B - C;
-                Func<double, double> PY = (t) => (F(t - C, Z2) - F(t - C, Z1)) / (Z2 - Z1);
-                prob *= PY(rate2_range.Item2) - PY(rate2_range.Item1);
-                if (prob == 0)
-                {
-                    return 0;
-                }
-            }
-
-            // * Then generate the real predicted range.
-            // We're doing things in different order then how we calculate probability,
-            // since forward prediction is more useful here.
-            //
 
             // Main spike 1
             int minPred = GetPrice(rateMin, buyPrice) - 1;
             int maxPred = GetPrice(rateMax, buyPrice) - 1;
             if (start < givenPrices.Length && givenPrices[start] > 0)
             {
+                if (givenPrices[start] < minPred - fudgeFactor || givenPrices[start] > maxPred + fudgeFactor)
+                {
+                    // Given price is out of predicted range, so this is the wrong pattern
+                    return false;
+                }
                 minPred = givenPrices[start];
                 maxPred = givenPrices[start];
             }
@@ -784,65 +399,78 @@ namespace TurnipTracker.Model
 
             // Main spike 2
             minPred = predictedPrices[start].min;
-            maxPred = GetPrice(rateMax, buyPrice);
+            maxPred = IntCeil(2.0 * buyPrice);
             if (start + 1 < givenPrices.Length && givenPrices[start + 1] > 0)
             {
+                if (givenPrices[start + 1] < minPred - fudgeFactor || givenPrices[start + 1] > maxPred + fudgeFactor)
+                {
+                    // Given price is out of predicted range, so this is the wrong pattern
+                    return false;
+                }
                 minPred = givenPrices[start + 1];
                 maxPred = givenPrices[start + 1];
             }
             predictedPrices.Add((minPred, maxPred));
 
             // Main spike 3
-            minPred = GetPrice(rateMin, buyPrice) - 1;
+            minPred = IntCeil(1.4 * buyPrice) - 1;
             maxPred = predictedPrices[start + 1].max - 1;
             if (start + 2 < givenPrices.Length && givenPrices[start + 2] > 0)
             {
+                if (givenPrices[start + 2] < minPred - fudgeFactor || givenPrices[start + 2] > maxPred + fudgeFactor)
+                {
+                    // Given price is out of predicted range, so this is the wrong pattern
+                    return false;
+                }
                 minPred = givenPrices[start + 2];
                 maxPred = givenPrices[start + 2];
             }
             predictedPrices.Add((minPred, maxPred));
 
-            return prob;
+            return true;
         }
 
-        PredictedPriceSeries? GeneratePatternFluctuatingWithLengths(
-                   int[] givenPrices,
-                   int highPhase1Len,
-                   int decPhase1Len,
-                   int highPhase2Len,
-                   int decPhase2Len,
-                   int highPhase3Len)
+        static PredictedPriceSeries? GeneratePatternFluctuatingWithLengths(
+                    int[] givenPrices,
+                    int highPhase1Len,
+                    int decPhase1Len,
+                    int highPhase2Len,
+                    int decPhase2Len,
+                    int highPhase3Len)
         {
             int buyPrice = givenPrices[0];
             var predictedPrices = new List<(int min, int max)> { (buyPrice, buyPrice), (buyPrice, buyPrice) };
-            double probability = 1;
 
             // High Phase 1
-            probability *= GenerateIndividualRandomPrice(
-                    givenPrices, predictedPrices, 2, highPhase1Len, 0.9, 1.4);
-            if (probability == 0)
+            if (!GenerateIndividualRandomPrice(
+                    givenPrices, predictedPrices, 2, highPhase1Len, 0.9, 1.4))
+            {
                 return null;
+            }
 
             // Dec Phase 1
-            probability *= GenerateDecreasingRandomPrice(
+            if (!GenerateDecreasingRandomPrice(
                     givenPrices, predictedPrices, 2 + highPhase1Len, decPhase1Len,
-                    0.6, 0.8, 0.04, 0.1);
-            if (probability == 0)
+                    0.6, 0.8, 0.04, 0.1))
+            {
                 return null;
+            }
 
             // High Phase 2
-            probability *= GenerateIndividualRandomPrice(givenPrices, predictedPrices,
-                2 + highPhase1Len + decPhase1Len, highPhase2Len, 0.9, 1.4);
-            if (probability == 0)
+            if (!GenerateIndividualRandomPrice(givenPrices, predictedPrices,
+                2 + highPhase1Len + decPhase1Len, highPhase2Len, 0.9, 1.4))
+            {
                 return null;
+            }
 
             // Dec Phase 2
-            probability *= GenerateDecreasingRandomPrice(
+            if (!GenerateDecreasingRandomPrice(
                     givenPrices, predictedPrices,
                     2 + highPhase1Len + decPhase1Len + highPhase2Len,
-                    decPhase2Len, 0.6, 0.8, 0.04, 0.1);
-            if (probability == 0)
+                    decPhase2Len, 0.6, 0.8, 0.04, 0.1))
+            {
                 return null;
+            }
 
             // High Phase 3
             if (2 + highPhase1Len + decPhase1Len + highPhase2Len + decPhase2Len + highPhase3Len != 14)
@@ -851,311 +479,236 @@ namespace TurnipTracker.Model
             }
 
             int prevLength = 2 + highPhase1Len + decPhase1Len + highPhase2Len + decPhase2Len;
-            probability *= probability *= GenerateIndividualRandomPrice(
+            if (!GenerateIndividualRandomPrice(
                      givenPrices, predictedPrices, prevLength, 14 - prevLength, 0.9,
-                    1.4);
-            if (probability == 0)
+                    1.4))
+            {
                 return null;
+            }
 
-            return new PredictedPriceSeries("Fluctuating", PredictionPattern.Fluctuating, predictedPrices, probability);
+            return new PredictedPriceSeries("Fluctuating", PredictionPattern.Fluctuating, predictedPrices);
         }
 
-        IEnumerable<PredictedPriceSeries> GeneratePatternFluctuating(int[] givenPrices)
+        static IEnumerable<PredictedPriceSeries> GeneratePatternFluctuating(int[] givenPrices)
         {
             for (var decPhase1Len = 2; decPhase1Len < 4; decPhase1Len++)
             {
                 for (var highPhase1Len = 0; highPhase1Len < 7; highPhase1Len++)
                 {
-                    double probability = 1.0 / (4.0 - 2.0) / 7.0 / (7.0 - highPhase1Len);
                     for (var highPhase3Len = 0; highPhase3Len < (7 - highPhase1Len - 1 + 1); highPhase3Len++)
                     {
                         var series = GeneratePatternFluctuatingWithLengths(givenPrices, highPhase1Len, decPhase1Len, 7 - highPhase1Len - highPhase3Len, 5 - decPhase1Len, highPhase3Len);
                         if (series != null)
-                            yield return multiply_generator_probability(series, probability);
+                            yield return series;
                     }
                 }
             }
         }
 
-        PredictedPriceSeries? GeneratePatternLargeSpikeWithPeak(
-          int[] givenPrices,
-          int peakStart)
+        static PredictedPriceSeries? GeneratePatternLargeSpikeWithPeak(
+           int[] givenPrices,
+           int peakStart)
         {
 
             int buyPrice = givenPrices[0];
             var predictedPrices = new List<(int min, int max)> { (buyPrice, buyPrice), (buyPrice, buyPrice) };
-            double probability = 1;
 
-            probability *= GenerateDecreasingRandomPrice(
-                    givenPrices, predictedPrices, 2, peakStart - 2, 0.85, 0.9, 0.03, 0.05);
-            if (probability == 0)
+            if (!GenerateDecreasingRandomPrice(
+                    givenPrices, predictedPrices, 2, peakStart - 2, 0.85, 0.9, 0.03, 0.05))
+            {
                 return null;
+            }
 
             // Now each day is independent of next
             var minRandoms = new double[] { 0.9, 1.4, 2.0, 1.4, 0.9, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4 };
             var maxRandoms = new double[] { 1.4, 2.0, 6.0, 2.0, 1.4, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9 };
             for (int i = peakStart; i < 14; i++)
             {
-                probability *= GenerateIndividualRandomPrice(
-                        givenPrices, predictedPrices, i, 1, minRandoms[i - peakStart], maxRandoms[i - peakStart]);
-                if (probability == 0)
+                if (!GenerateIndividualRandomPrice(
+                        givenPrices, predictedPrices, i, 1, minRandoms[i - peakStart], maxRandoms[i - peakStart]))
+                {
                     return null;
+                }
             }
-            return new PredictedPriceSeries("Large spike", PredictionPattern.LargeSpike, predictedPrices, probability);
+            return new PredictedPriceSeries("Large spike", PredictionPattern.LargeSpike, predictedPrices);
         }
 
-        IEnumerable<PredictedPriceSeries> GeneratePatternLargeSpike(int[] givenPrices)
+        static IEnumerable<PredictedPriceSeries> GeneratePatternLargeSpike(int[] givenPrices)
         {
-            const double probability = 1.0 / (10.0 - 3.0);
             for (var peakStart = 3; peakStart < 10; peakStart++)
             {
                 var series = GeneratePatternLargeSpikeWithPeak(givenPrices, peakStart);
                 if (series != null)
-                    yield return multiply_generator_probability(series, probability);
+                    yield return series;
             }
         }
 
-        IEnumerable<PredictedPriceSeries> GeneratePatternDecreasing(int[] givenPrices)
+        static IEnumerable<PredictedPriceSeries> GeneratePatternDecreasing(int[] givenPrices)
         {
             var buyPrice = givenPrices[0];
             var predictedPrices = new List<(int min, int max)> { (buyPrice, buyPrice), (buyPrice, buyPrice) };
-            double probability = 1;
 
-            probability *= GenerateDecreasingRandomPrice(
-                    givenPrices, predictedPrices, 2, 14 - 2, 0.85, 0.9, 0.03, 0.05);
-            if (probability == 0)
+            if (!GenerateDecreasingRandomPrice(
+                    givenPrices, predictedPrices, 2, 14 - 2, 0.85, 0.9, 0.03, 0.05))
+            {
                 yield break;
+            }
 
-            yield return new PredictedPriceSeries("Decreasing", PredictionPattern.Decreasing, predictedPrices, probability);
+            yield return new PredictedPriceSeries("Decreasingg", PredictionPattern.Decreasing, predictedPrices);
         }
 
-        PredictedPriceSeries? GeneratePatternSmallSpikeWithPeak(
-           int[] givenPrices,
-           int peakStart)
+        static PredictedPriceSeries? GeneratePatternSmallSpikeWithPeak(
+            int[] givenPrices,
+            int peakStart)
         {
             var buyPrice = givenPrices[0];
             var predictedPrices = new List<(int min, int max)> { (buyPrice, buyPrice), (buyPrice, buyPrice) };
-            double probability = 1;
 
-            probability *= GenerateDecreasingRandomPrice(
+            if (!GenerateDecreasingRandomPrice(
                     givenPrices, predictedPrices, 2, peakStart - 2, 0.4, 0.9, 0.03,
-                    0.05);
-            if (probability == 0)
+                    0.05))
+            {
                 return null;
+            }
 
             // The peak
-            probability *= GenerateIndividualRandomPrice(
-                    givenPrices, predictedPrices, peakStart, 2, 0.9, 1.4);
-            if (probability == 0)
+            if (!GenerateIndividualRandomPrice(
+                    givenPrices, predictedPrices, peakStart, 2, 0.9, 1.4))
+            {
                 return null;
+            }
 
-            probability *= GeneratePeakPrice(
-                    givenPrices, predictedPrices, peakStart + 2, 1.4, 2.0);
-            if (probability == 0)
+            if (!GeneratePeakPrice(
+                    givenPrices, predictedPrices, peakStart + 2, 1.4, 2.0))
+            {
                 return null;
+            }
 
             if (peakStart + 5 < 14)
             {
-                probability *= GenerateDecreasingRandomPrice(
+                if (!GenerateDecreasingRandomPrice(
                         givenPrices, predictedPrices, peakStart + 5,
-                        14 - (peakStart + 5), 0.4, 0.9, 0.03, 0.05);
-                if (probability == 0)
+                        14 - (peakStart + 5), 0.4, 0.9, 0.03, 0.05))
+                {
                     return null;
+                }
             }
 
-            return new PredictedPriceSeries("Small spike", PredictionPattern.SmallSpike, predictedPrices, probability);
+            return new PredictedPriceSeries("Small spike", PredictionPattern.SmallSpike, predictedPrices);
         }
 
-        IEnumerable<PredictedPriceSeries> GeneratePatternSmallSpike(int[] givenPrices)
+        static IEnumerable<PredictedPriceSeries> GeneratePatternSmallSpike(int[] givenPrices)
         {
-            const double probability = 1.0 / (10.0 - 2.0);
             for (var peakStart = 2; peakStart < 10; peakStart++)
             {
                 var series = GeneratePatternSmallSpikeWithPeak(givenPrices, peakStart);
                 if (series != null)
-                    yield return multiply_generator_probability(series, probability);
+                    yield return series;
             }
         }
 
-        static Dictionary<PredictionPattern, double> get_transition_probability(PredictionPattern previous_pattern)
+        static List<PredictedPriceSeries> GeneratePossibilities(int[] sellPrices)
         {
-            if (probabilityMatrix.TryGetValue(previous_pattern, out var probabilities))
-                return probabilities;
-
-            // Use the steady state probabilities of PROBABILITY_MATRIX if we don't
-            // know what the previous pattern was.
-            // See https://github.com/mikebryant/ac-nh-turnip-prices/issues/68
-            // and https://github.com/mikebryant/ac-nh-turnip-prices/pull/90
-            // for more information.
-            return new Dictionary<PredictionPattern, double> {
-                    { PredictionPattern.Fluctuating, 4530.0 / 13082.0 },
-                    { PredictionPattern.LargeSpike, 3236.0 / 13082.0 },
-                    { PredictionPattern.Decreasing, 1931.0 / 13082.0 },
-                    { PredictionPattern.SmallSpike, 3385.0 / 13082.0 }
-            };
-        }
-
-        List<PredictedPriceSeries> generate_all_patterns(int[] sell_prices, PredictionPattern previous_pattern)
-        {
-            var generate_pattern_fns =
-                new Func<int[], IEnumerable<PredictedPriceSeries>>[]{
-                       GeneratePatternFluctuating,
-                       GeneratePatternLargeSpike,
-                       GeneratePatternDecreasing,
-                       GeneratePatternSmallSpike,
-                };
-
-            var transition_probability = get_transition_probability(previous_pattern);
-
-            var allPaterns = new List<PredictedPriceSeries>();
-            foreach (var fn in generate_pattern_fns)
+            var possibilities = new List<PredictedPriceSeries>();
+            if (sellPrices[0] > 0)
             {
-                foreach (var pps in fn(sell_prices))
-                {
-                    double probability = transition_probability[pps.PatternNumber];
-                    allPaterns.Add(multiply_generator_probability(pps, probability));
-                }
-            }
-            return allPaterns;
-        }
-
-        List<PredictedPriceSeries> GeneratePossibilities(int[] sellPrices, bool first_buy, PredictionPattern previous_pattern)
-        {
-            if (first_buy || sellPrices[0] == 0)
-            {
-                var possibilities = new List<PredictedPriceSeries>();
-                for (int buy_price = 90; buy_price <= 110; buy_price++)
-                {
-                    var temp_sell_prices = new int[sellPrices.Length];
-                    Array.Copy(sellPrices, temp_sell_prices, sellPrices.Length);
-                    temp_sell_prices[0] = temp_sell_prices[1] = buy_price;
-                    if (first_buy)
-                    {
-                        possibilities.AddRange(GeneratePatternSmallSpike(temp_sell_prices));
-                    }
-                    else
-                    {
-                        // All buy prices are equal probability and we're at the outmost layer,
-                        // so don't need to multiply_generator_probability here.
-                        possibilities.AddRange(generate_all_patterns(temp_sell_prices, previous_pattern));
-                    }
-                }
-                return possibilities;
+                possibilities.AddRange(Enumerate(sellPrices));
             }
             else
             {
-                return generate_all_patterns(sellPrices, previous_pattern);
-
+                for (var buyPrice = 90; buyPrice <= 110; buyPrice++)
+                {
+                    // Create a copy so as not to mutate passed in values
+                    var iterSellPrices = new int[sellPrices.Length];
+                    Array.Copy(sellPrices, iterSellPrices, sellPrices.Length);
+                    iterSellPrices[0] = iterSellPrices[1] = buyPrice;
+                    possibilities.AddRange(Enumerate(iterSellPrices));
+                }
             }
+            static IEnumerable<PredictedPriceSeries> Enumerate(int[] sellPrices)
+            {
+                foreach (var series in GeneratePatternFluctuating(sellPrices))
+                    yield return series;
+                foreach (var series in GeneratePatternLargeSpike(sellPrices))
+                    yield return series;
+                foreach (var series in GeneratePatternDecreasing(sellPrices))
+                    yield return series;
+                foreach (var series in GeneratePatternSmallSpike(sellPrices))
+                    yield return series;
+            }
+            return possibilities;
         }
 
-        public List<PredictedPriceSeries> AnalyzePossibilities()
+        static double RowProbability(PredictedPriceSeries possibility, PredictionPattern previousPattern)
+            => probabilityMatrix[previousPattern][possibility.PatternNumber] / patternCounts[possibility.PatternNumber];
+
+        static List<PredictedPriceSeries> GetProbabilities(List<PredictedPriceSeries> possibilities, PredictionPattern previousPattern)
         {
-            int[] sell_prices = Prices;
-            bool first_buy = FirstBuy;
-            var previous_pattern = PreviousPattern;
-            var generated_possibilities = new List<PredictedPriceSeries>();
-            for (int i = 0; i < 6; i++)
+            if (previousPattern == PredictionPattern.IDontKnow || previousPattern == PredictionPattern.All)
             {
-                FudgeFactor = i;
-                generated_possibilities = GeneratePossibilities(sell_prices, first_buy, previous_pattern);
-                if (generated_possibilities.Count > 0)
-                {
-                    //Console.WriteLine($"Generated possibilities using fudge factor {i}");
-                    break;
-                }
+                return possibilities;
             }
 
-            double total_probability = 0;
-            foreach (var it in generated_possibilities)
-                total_probability += it.Probability;
-            foreach (var it in generated_possibilities)
-                it.Probability /= total_probability;
+            var maxPercent = possibilities.Select((poss) => RowProbability(poss, previousPattern)).Sum();
 
-            foreach (var poss in generated_possibilities)
+            for (int i = 0; i < possibilities.Count; i++)
             {
-                var weekMins = new List<int>();
-                var weekMaxes = new List<int>();
-                for (var i = 2; i < 14; i++)
-                {
-                    var day = poss.Prices[i];
-                    // Check for a future date by checking for a range of prices
-                    if (day.min != day.max)
-                    {
-                        weekMins.Add(day.min);
-                        weekMaxes.Add(day.max);
-                    }
-                    else
-                    {
-                        // If we find a set price after one or more ranged prices, the user has missed a day. Discard that data and start again.
-                        weekMins.Clear();
-                        weekMaxes.Clear();
-                    }
-                }
-                if (weekMins.Count == 0 && weekMaxes.Count == 0)
-                {
-                    weekMins.Add(poss.Prices[poss.Prices.Count - 1].min);
-                    weekMaxes.Add(poss.Prices[poss.Prices.Count - 1].max);
-                }
-                poss.WeekGuaranteedMinimum = weekMins.Max();
-                poss.WeekMax = weekMaxes.Max();
+                possibilities[i].Probability = RowProbability(possibilities[i], previousPattern) / maxPercent;
             }
-
-            var category_totals = new Dictionary<PredictionPattern, double>();
-            foreach (var possibility in generated_possibilities)
-            {
-                if (!category_totals.ContainsKey(possibility.PatternNumber))
-                    category_totals[possibility.PatternNumber] = 0;
-                category_totals[possibility.PatternNumber] += possibility.Probability;
-            }
-
-            foreach (var pos in generated_possibilities)
-            {
-                pos.CategoryTotalProbability = category_totals[pos.PatternNumber];
-            }
-
-            generated_possibilities.Sort(
-                (a, b) => (b.CategoryTotalProbability != a.CategoryTotalProbability) ?
-                  b.CategoryTotalProbability.CompareTo(a.CategoryTotalProbability) : b.Probability.CompareTo(a.Probability));
-
-            var global_min_max = new List<(int min, int max)>();
-            for (int day = 0; day < 14; day++)
-            {
-                var prices = (min: 999, max: 0);
-                foreach (var poss in generated_possibilities)
-                {
-                    if (poss.Prices[day].min < prices.min)
-                    {
-                        prices.min = poss.Prices[day].min;
-                    }
-                    if (poss.Prices[day].max > prices.max)
-                    {
-                        prices.max = poss.Prices[day].max;
-                    }
-                }
-                global_min_max.Add(prices);
-            }
-
-            var allSeries = new PredictedPriceSeries("All patterns", PredictionPattern.All, global_min_max, 0);
-            allSeries.WeekGuaranteedMinimum = generated_possibilities.Count == 0 ? 0 : generated_possibilities.Select(poss => poss.WeekGuaranteedMinimum).Min();
-            allSeries.WeekMax = generated_possibilities.Count == 0 ? 0 : generated_possibilities.Select(poss => poss.WeekMax).Max();
-            allSeries.Probability = 1;
-            allSeries.CategoryTotalProbability = 1;
-            generated_possibilities.Insert(0, allSeries);
-
-            return generated_possibilities;
+            return possibilities;
         }
-    }
 
-    static class Extensions
-    {
-        // returns a shallow copy of a portion of an array into a new array object selected from begin to end (end not included) 
-        public static T[] Slice<T>(this T[] array, int start, int end)
+        public static List<PredictedPriceSeries> AnalyzePossibilities(int[] sellPrices, PredictionPattern previousPattern)
         {
-            var slice = new T[end - start];
-            for (var i = 0; i < slice.Length; i++)
-                slice[i] = array[start + i];
-            return slice;
+            if (sellPrices == null) throw new ArgumentNullException(nameof(sellPrices));
+
+            var generatedPossibilities = GeneratePossibilities(sellPrices);
+            GetProbabilities(generatedPossibilities, previousPattern);
+
+            var dailyMinMax = GetDailyMinMax(generatedPossibilities);
+            generatedPossibilities.Add(dailyMinMax);
+
+            return generatedPossibilities;
+        }
+
+        public static PredictedPriceSeries GetDailyMinMax(int[] sellPrices)
+        {
+            if (sellPrices == null) throw new ArgumentNullException(nameof(sellPrices));
+
+            var generatedPossibilities = GeneratePossibilities(sellPrices);
+            var dailyMinMax = GetDailyMinMax(generatedPossibilities);
+            return dailyMinMax;
+        }
+
+        static PredictedPriceSeries GetDailyMinMax(List<PredictedPriceSeries> series)
+        {
+            var weekMinMaxs = new List<(int min, int max)>();
+            for (var i = 0; i < 14; i++)
+            {
+                int min;
+                int max;
+                if (series.Count == 0)
+                {
+                    // If no series found then return 0 to 999
+                    // This happens when the input data is invalid
+                    min = 0;
+                    max = 999;
+                }
+                else
+                {
+                    min = int.MaxValue;
+                    max = 0;
+                    foreach (var entry in series)
+                    {
+                        if (entry.Prices[i].min < min)
+                            min = entry.Prices[i].min;
+                        if (entry.Prices[i].max > max)
+                            max = entry.Prices[i].max;
+                    }
+                }
+                weekMinMaxs.Add((min, max));
+            }
+            return new PredictedPriceSeries("All patterns", PredictionPattern.All, weekMinMaxs);
         }
     }
 }

--- a/TurnipTracker/ViewModel/TrackingViewModel.cs
+++ b/TurnipTracker/ViewModel/TrackingViewModel.cs
@@ -145,7 +145,7 @@ namespace TurnipTracker.ViewModel
 
         public void UpdatePredications()
         {
-            
+            PredictionUpdater.Update(Days);
 
             var sunday = Days[0];
             if ((sunday.BuyPrice.HasValue || sunday.ActualPurchasePrice.HasValue) && SelectedDay != sunday)
@@ -177,17 +177,43 @@ namespace TurnipTracker.ViewModel
                     SelectedDay.DifferencePM = string.Empty;
                 }
             }
-            try
+
+            var low = 0;
+            var high = 0;
+            foreach (var day in Days)
             {
-                var (minSell, maxSell) = PredictionUpdater.Update(Days);
-                Min = minSell;
-                Max = maxSell;
+
+                if (day == sunday)
+                {
+
+                    var val = day.BuyPrice ?? 0;
+                    continue;
+                }
+
+
+                if (!day.PriceAM.HasValue)
+                {
+                    if (day.PredictionAMMin > low)
+                        low = day.PredictionAMMin;
+
+                    if (day.PredictionAMMax > high)
+                        high = day.PredictionAMMax;
+                }
+
+                if (!day.PricePM.HasValue)
+                {
+                    if (day.PredictionPMMin > low)
+                        low = day.PredictionPMMin;
+
+                    if (day.PredictionPMMax > high)
+                        high = day.PredictionPMMax;
+
+                }
             }
-            catch(Exception ex)
-            {
-                Min = 0;
-                Max = 0;
-            }
+
+            Min = low;
+            Max = high;
+
 
             if (IsGraphExpanded)
                 UpdateGraph();


### PR DESCRIPTION
I managed to get the iOS simulator working and fixed the crash however the new method of calculating all the probabilities makes the updates slow causing the app to be sluggish when switching between days, you can try it here: https://github.com/sparkie108/app-ac-islandtracker/tree/fix-predictor.  Even though we don't display the probabilities the most recent version checks if a series is valid or not by seeing if the probability is greater than zero or not.

So I have created this PR to regress the Predictor to the previous version, so that the app stops crashing and remains responsive.
